### PR TITLE
Add requests __name property.

### DIFF
--- a/src/TypeScriptGeneration.RequestHandlers.Tests/Test.cs
+++ b/src/TypeScriptGeneration.RequestHandlers.Tests/Test.cs
@@ -48,6 +48,7 @@ export class TestRequest {
         public id?: string) {
     }
 
+    public __name = 'TestRequest';
     private __request = () => {
         const req: IHttpRequest<TestResponse> = {
             method: 'get',

--- a/src/TypeScriptGeneration.RequestHandlers/RequestConverter.cs
+++ b/src/TypeScriptGeneration.RequestHandlers/RequestConverter.cs
@@ -62,6 +62,7 @@ namespace TypeScriptGeneration.RequestHandlers
             var routePropertyName = PropName(context, httpRequestType, nameof(IHttpRequest<object>.Route));
             var bodyPropertyName = PropName(context, httpRequestType, nameof(IHttpRequest<object>.Body));
             var code = $@"
+public __name = '{context.Configuration.GetTypeName(type)}';
 private __request = () => {{
     const req: {context.GetTypeScriptType(httpRequestType).ToTypeScriptType()} = {{
         {methodPropertyName}: '{parsed.HttpMethod.ToString().ToLower()}',


### PR DESCRIPTION
TypeScript lacks a c#-style nameof() function, so we generate a __name property for each request.
That property can be used for logging when starting a request.
The name used is the type name without generic types.