### PR TITLE
Use asp.net core query string model binding as default.

### DIFF
--- a/src/TypeScriptGeneration.Core/ILocalConvertContext.cs
+++ b/src/TypeScriptGeneration.Core/ILocalConvertContext.cs
@@ -8,6 +8,7 @@ namespace TypeScriptGeneration
     {
         TypeScriptType GetTypeScriptType(Type t);
         ConvertConfiguration Configuration { get; }
+        Dictionary<Type, TypeScriptResult> Imports { get; }
         Dictionary<TypeScriptType[], string> ExternalImports { get; }
     }
 }

--- a/src/TypeScriptGeneration.RequestHandlers.Tests/Test.cs
+++ b/src/TypeScriptGeneration.RequestHandlers.Tests/Test.cs
@@ -39,13 +39,16 @@ import { IHttpRequest } from './IHttpRequest';
 export interface IRequestDispatcher {
     execute<TResponse>(request: IHttpRequest<TResponse>): Observable<TResponse>;
 }"},
-                {"TestRequest.ts", @"import { IHttpRequest } from './IHttpRequest';
+                {"TestRequest.ts", @"import { TestFilterDto } from './TestFilterDto';
+import { IHttpRequest } from './IHttpRequest';
 import { TestResponse } from './TestResponse';
 import { IRequestDispatcher } from './IRequestDispatcher';
 
 export class TestRequest {
     constructor(
-        public id?: string) {
+        public id?: string,
+        public numbers?: Array<number>,
+        public filter?: TestFilterDto) {
     }
 
     public __name = 'TestRequest';
@@ -56,13 +59,49 @@ export class TestRequest {
             body: undefined,
             queryString: {}
         };
+        if (this.numbers) req.queryString['numbers'] = this.numbers.map(i => i ? i.toString() : null).filter(i => typeof i === 'string');
+        if (this.filter) {
+            if (this.filter.search) req.queryString['filter.search'] = this.filter.search;
+            if (this.filter.page) {
+                if (this.filter.page.size) req.queryString['filter.page.size'] = this.filter.page.size.toString();
+                if (this.filter.page.index) req.queryString['filter.page.index'] = this.filter.page.index.toString();
+            }
+        }
+
         return req;
     }
     public execute = (dispatcher: IRequestDispatcher) => dispatcher.execute(this.__request());
-}"},
+}
+"},
                 {"TestResponse.ts", @"export class TestResponse {
     constructor(
         public date?: Date) {
+    }
+}
+"},
+                {"TestFilterDto.ts", @"import { PageDto } from './PageDto';
+import { PagedFilterDto } from './PagedFilterDto';
+
+export class TestFilterDto extends PagedFilterDto {
+    constructor(
+        page?: PageDto,
+        public search?: string) {
+        super(page);
+    }
+}
+"},
+                {"PagedFilterDto.ts", @"import { PageDto } from './PageDto';
+
+export class PagedFilterDto {
+    constructor(
+        public page?: PageDto) {
+    }
+}
+"},
+                {"PageDto.ts", @"export class PageDto {
+    constructor(
+        public size?: number,
+        public index?: number) {
     }
 }
 "}
@@ -71,7 +110,10 @@ export class TestRequest {
             expected.All(x => files.ContainsKey(x.Key)).Should().BeTrue("Expected file is not found in actual");
             files.All(x => expected.ContainsKey(x.Key)).Should().BeTrue("Actual file is not found in expected");
 
-            expected.ToList().ForEach(x => files[x.Key].Should().BeLike(x.Value));
+            foreach (var expectedFile in expected)
+            {
+                expectedFile.Value.Should().BeLike(files[expectedFile.Key], $"File content for {expectedFile.Key} does not match the expected value.");
+            }
         }
     }
 
@@ -79,10 +121,28 @@ export class TestRequest {
     public class TestRequest : IReturn<TestResponse>
     {
         public string Id { get; set; }
+        public List<int> Numbers { get; set; }
+        public TestFilterDto Filter { get; set; }
     }
 
     public class TestResponse
     {
         public DateTime Date { get; set; }
+    }
+
+    public class TestFilterDto : PagedFilterDto
+    {
+        public string Search { get; set; }
+    }
+
+    public class PagedFilterDto
+    {
+        public PageDto Page { get; set; }
+    }
+
+    public class PageDto
+    {
+        public long Size { get; set; }
+        public long Index { get; set; }
     }
 }

--- a/src/TypeScriptGeneration.RequestHandlers/AspNetQueryStringConverter.cs
+++ b/src/TypeScriptGeneration.RequestHandlers/AspNetQueryStringConverter.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using TypeScriptGeneration.Converters;
+
+namespace TypeScriptGeneration.RequestHandlers
+{
+    /*
+     An implementation for the default .NET query string binder.
+     E.g.:
+     Given the following request GET-method signature where all parameters are bound as Query type:
+       MyMethod(string name, Filter filter)
+     with the Filter class looking like:
+       public class Filter
+       {
+           public string Search { get; set; }
+           public Page Page { get; set; }
+       }
+     and the Page class looking like:
+       public class Page
+       {
+           public int Index { get; set; }
+           public int Size { get; set; }
+       }
+     
+     will result in the following query parameters:
+       - Name
+       - Filter.Search
+       - Filter.Page.Index
+       - Filter.Page.Size
+     (notice the lack of Filter prefix anywhere)
+    */
+    public static class AspNetQueryStringConverter
+    {
+        public static string GetQueryStringLines(IEnumerable<ClassConverter.Property> properties, string queryStringPropertyName, ILocalConvertContext context)
+        {
+            var queryStringBuilder = new StringBuilder();
+
+            foreach (var property in properties)
+            {
+                queryStringBuilder.AppendQueryStringLines("    ", property.PropertyInfo, context.Imports, context.Configuration.GetPropertyName,
+                    property.Name, queryStringPropertyName);
+            }
+
+            return queryStringBuilder.ToString();
+        }
+
+        private static void AppendQueryStringLines(this StringBuilder builder, string linePrefix, PropertyInfo propertyInfo,
+            IDictionary<Type, TypeScriptResult> imports, Func<Type, PropertyInfo, string> getTypescriptPropertyName,
+            string propertyName, string queryStringPropertyName)
+        {
+            var defaultCondition = $"if (this.{propertyName})";
+            var defaultLeftHandSide = $"req.{queryStringPropertyName}['{propertyName}']";
+            var propertyType = propertyInfo.PropertyType;
+            var isEnumerableOrArray = propertyType.IsArray || typeof(IEnumerable).IsAssignableFrom(propertyType);
+            
+            if (propertyType == typeof(string))
+            {
+                builder.AppendLine($"{linePrefix}{defaultCondition} {defaultLeftHandSide} = this.{propertyName};");
+            }
+            else if (isEnumerableOrArray)
+            {
+                builder.AppendLine($"{linePrefix}{defaultCondition} {defaultLeftHandSide} = this.{propertyName}.map(i => i ? i.toString() : null).filter(i => typeof i === 'string');");
+            }
+            else if (imports.ContainsKey(propertyType))
+            {
+                var import = imports[propertyType];
+
+                builder.AppendLine($"{linePrefix}{defaultCondition} {{");
+                var innerProperties = propertyInfo.PropertyType.GetProperties(
+                    BindingFlags.Instance |
+                    BindingFlags.Public |
+                    BindingFlags.SetProperty |
+                    BindingFlags.GetProperty);
+                foreach (var innerPropertyInfo in innerProperties)
+                {
+                    var innerImports = import.Imports.ToDictionary(x => x.Type, x => x);
+                    var newPropertyNamePart = getTypescriptPropertyName(propertyType, innerPropertyInfo);
+                    var innerPropertyName = $"{propertyName}.{newPropertyNamePart}";
+                    
+                    builder.AppendQueryStringLines($"{linePrefix}    ",innerPropertyInfo, innerImports, getTypescriptPropertyName,
+                        innerPropertyName, queryStringPropertyName);
+                }
+
+                builder.AppendLine($"{linePrefix}}}");
+            }
+            else
+            {
+                builder.AppendLine($"{linePrefix}{defaultCondition} {defaultLeftHandSide} = this.{propertyName}.toString();");
+            }
+        }
+    }
+}


### PR DESCRIPTION
I've created a new way of binding the query parameters for a GET-request.
The RequestConverter class now accepts a new constructor parameter in order to allow customization if needed.